### PR TITLE
Add default datatype for LoggedStatement->bindValue according to parent class

### DIFF
--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -45,7 +45,7 @@ class LoggedStatement extends PDOStatement
     public function bindValue(
         $parameter,
         $value,
-        $dataType = null
+        $dataType = \PDO::PARAM_STR
     ) : bool
     {
         $result = parent::bindValue($parameter, $value, $dataType);


### PR DESCRIPTION
This PR adds the default `\PDO::PARAM_STR` data type value to `LoggerStatement->bindValue`.

Without this default value, activating the Query Logger make any of the subsequent `\Atlas\Pdo\Connection` query methods fails when data types aren't provided.