### PR TITLE
fix a wrong description for ConnectionLocator::getWrite()

### DIFF
--- a/docs/connection-locator.md
+++ b/docs/connection-locator.md
@@ -67,7 +67,7 @@ Retrieve a _Connection_ from the locator when you need it. This will create the 
 
 - `getRead()` will return a random read _Connection_; after the first call, `getRead()` will always return the same _Connection_. (If no read _Connections_ are defined, it will return the default connection.)
 
-- `getWrite()` will return a random write _Connection_; after the first call, `getWrite()` will always return the same _Connection_. (If no read _Connections_ are defined, it will return the default connection.)
+- `getWrite()` will return a random write _Connection_; after the first call, `getWrite()` will always return the same _Connection_. (If no write _Connections_ are defined, it will return the default connection.)
 
 ```php
 $read = $connectionLocator->getRead();


### PR DESCRIPTION
I read the doc and found a mistake.
s/read/write/