### PR TITLE
fix a syntax error in example code

### DIFF
--- a/docs/connection-locator.md
+++ b/docs/connection-locator.md
@@ -37,12 +37,10 @@ $connectionLocator->setWriteFactory('master', Connection::factory(
 
 // read (slave) #1
 $connectionLocator->setReadFactory('slave1', Connection::factory(
-    return new Connection(
-        'mysql:host=slave1.db.localhost;dbname=database',
-        'username',
-        'password'
-    );
-});
+    'mysql:host=slave1.db.localhost;dbname=database',
+    'username',
+    'password'
+));
 
 // read (slave) #2
 $connectionLocator->setReadFactory('slave2', Connection::factory(


### PR DESCRIPTION
This pr uses Connection::factory() as the second argument in the same way as other setReadFactory() codes.
Is it better to show we can also use an anonymous function?

```
// read (slave) #1
$connectionLocator->setReadFactory('slave1', function() {
    return Connection::new(
        'mysql:host=slave1.db.localhost;dbname=database',
        'username',
        'password'
    );
});
```