### PR TITLE
fix LoggedStatement cannot execute if not init logEntry and queryLogger

### DIFF
--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -30,7 +30,7 @@ class LoggedStatement extends PDOStatement
 
     public function execute($inputParameters = null) : bool
     {
-        if ($inputParameters !== null) {
+        if ($inputParameters !== null && $this->logEntry) {
             $this->logEntry['values'] = array_replace(
                 $this->logEntry['values'],
                 $inputParameters
@@ -38,7 +38,9 @@ class LoggedStatement extends PDOStatement
         }
 
         $result = parent::execute($inputParameters);
-        ($this->queryLogger)($this->logEntry);
+        if ($this->queryLogger && $this->logEntry) {
+            ($this->queryLogger)($this->logEntry);
+        }
         return $result;
     }
 
@@ -49,7 +51,7 @@ class LoggedStatement extends PDOStatement
     ) : bool
     {
         $result = parent::bindValue($parameter, $value, $dataType);
-        if ($result) {
+        if ($result && $this->logEntry) {
             $this->logEntry['values'][$parameter] = $value;
         }
         return $result;

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -383,4 +383,20 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($query['values']['id'] === '0');
         $this->assertTrue($query['trace'] != '');
     }
+
+    public function testLoggedStatementCreateFromPdoPrepare()
+    {
+        // query logging turned on
+        $this->connection->logQueries(true);
+
+        $stm = "SELECT id FROM pdotest WHERE id = 0";
+        // prepare from native pdo
+        $sth = $this->pdo->prepare($stm);
+        $this->assertInstanceOf(PDOStatement::CLASS, $sth);
+        $this->assertInstanceOf(LoggedStatement::CLASS, $sth);
+
+        $this->assertTrue($sth->execute());
+        $queries = $this->connection->getQueries();
+        $this->assertCount(0, $queries);
+    }
 }


### PR DESCRIPTION
fix #9 

If `LoggedStatement` not set the `logEntry` and `queryLogger`, degenerative back to `PdoStatement`.