### PR TITLE
Allow ConnectionLocator to be used with PDO Persistent Connections

### DIFF
--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -15,9 +15,16 @@ use PDOStatement;
 
 class LoggedStatement extends PDOStatement
 {
+    private $statement;
+
     private $logEntry;
 
     private $queryLogger;
+
+    public function __construct(PDOStatement $statement)
+    {
+        $this->statement = $statement;
+    }
 
     public function setLogEntry(array $logEntry) : void
     {
@@ -31,7 +38,7 @@ class LoggedStatement extends PDOStatement
 
     public function execute($inputParameters = null) : bool
     {
-        $result = parent::execute($inputParameters);
+        $result = $this->statement->execute($inputParameters);
         $this->log($inputParameters);
         return $result;
     }
@@ -58,10 +65,100 @@ class LoggedStatement extends PDOStatement
         $dataType = PDO::PARAM_STR
     ) : bool
     {
-        $result = parent::bindValue($parameter, $value, $dataType);
+        $result = $this->statement->bindValue($parameter, $value, $dataType);
         if ($result && $this->logEntry !== null) {
             $this->logEntry['values'][$parameter] = $value;
         }
         return $result;
+    }
+
+    public function fetch($fetch_style = null, $cursor_orientation = PDO::FETCH_ORI_NEXT, $cursor_offset = 0)
+    {
+        return $this->statement->fetch(...func_get_args());
+    }
+
+    public function bindParam(
+        $parameter,
+        &$variable,
+        $data_type = PDO::PARAM_STR,
+        $length = null,
+        $driver_options = null
+    ) {
+        return $this->statement->bindParam(...func_get_args());
+    }
+
+    public function bindColumn($column, &$param, $type = null, $maxlen = null, $driverdata = null)
+    {
+        return $this->statement->bindColumn(...func_get_args());
+    }
+
+    public function rowCount()
+    {
+        return $this->statement->rowCount();
+    }
+
+    public function fetchColumn($column_number = 0)
+    {
+        return $this->statement->fetchColumn(...func_get_args());
+    }
+
+    public function fetchAll($fetch_style = null, $fetch_argument = null, $ctor_args = [])
+    {
+        return $this->statement->fetchAll(...func_get_args());
+    }
+
+    public function fetchObject($class_name = "stdClass", $ctor_args = [])
+    {
+        return $this->statement->fetchObject(...func_get_args());
+    }
+
+    public function errorCode()
+    {
+        return $this->statement->errorCode();
+    }
+
+    public function errorInfo()
+    {
+        return $this->statement->errorInfo();
+    }
+
+    public function setAttribute($attribute, $value)
+    {
+        return $this->statement->setAttribute($attribute, $value);
+    }
+
+    public function getAttribute($attribute)
+    {
+        return $this->statement->getAttribute($attribute);
+    }
+
+    public function columnCount()
+    {
+        return $this->statement->columnCount();
+    }
+
+    public function getColumnMeta($column)
+    {
+        return $this->statement->getColumnMeta($column);
+    }
+
+    public function setFetchMode($mode, $classNameObject = null, array $ctorarfg = [])
+    {
+        return $this->statement->setFetchMode(...func_get_args());
+    }
+
+    public function nextRowset()
+    {
+        return $this->statement->nextRowset();
+    }
+
+    public function closeCursor()
+    {
+        return $this->statement->closeCursor();
+    }
+
+    public function debugDumpParams()
+    {
+        return $this->statement->debugDumpParams();
     }
 }

--- a/tests/ConnectionLocatorTest.php
+++ b/tests/ConnectionLocatorTest.php
@@ -254,4 +254,19 @@ class ConnectionLocatorTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(1, $entries);
         $this->assertSame('SELECT * FROM sqlite_master', $entries[0]['statement']);
     }
+
+    public function testPersistentConnections()
+    {
+        $locator = $this->newLocator();
+        $locator->setWriteFactory('persistent-connection', Connection::factory(
+            'sqlite::memory:',
+            '',
+            '',
+            [PDO::ATTR_PERSISTENT => true]
+        ));
+
+        $connection = $locator->get(ConnectionLocator::WRITE, 'persistent-connection');
+
+        $this->assertInstanceOf(Connection::class, $connection);
+    }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -383,20 +383,4 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($query['values']['id'] === '0');
         $this->assertTrue($query['trace'] != '');
     }
-
-    public function testLoggedStatementCreateFromPdoPrepare()
-    {
-        // query logging turned on
-        $this->connection->logQueries(true);
-
-        $stm = "SELECT id FROM pdotest WHERE id = 0";
-        // prepare from native pdo
-        $sth = $this->pdo->prepare($stm);
-        $this->assertInstanceOf(PDOStatement::CLASS, $sth);
-        $this->assertInstanceOf(LoggedStatement::CLASS, $sth);
-
-        $this->assertTrue($sth->execute());
-        $queries = $this->connection->getQueries();
-        $this->assertCount(0, $queries);
-    }
 }


### PR DESCRIPTION
This PR modifies the `LoggedStatement` class to be a proxy wrapping the `PDOStatement` class, which is constructed by the `Connection` class injecting the `PDOStatement` into it when logging is enabled.

This allows persistent connections to be used along with the logging functionality and the `ConnectionLocator`.

In order to maintain the existing type hints for methods returning a `PDOStatement` instance, this was done by overriding each of the method of the parent class as opposed to using the magic `__call` method.

A test case was added to cover the case of a `ConnectionLocator` with a persistent connection, and an existing test case, which verified that `PDO` natively returned `LoggedStatement` instances, was removed as it would no longer be applicable.