### PR TITLE
Upgrades to typehints and PHP 8.4 method signatures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: PHP Composer
+
+on:
+  push:
+    branches: [ "2.x" ]
+  pull_request:
+    branches: [ "2.x" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
+    # Docs: https://getcomposer.org/doc/articles/scripts.md
+
+    # - name: Run test suite
+    #   run: composer run-script test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,96 @@
-name: PHP Composer
+name: Atlas.Pdo CI
 
 on:
   push:
-    branches: [ "2.x" ]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
   pull_request:
-    branches: [ "2.x" ]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  workflow_dispatch:
+
+env:
+  fail-fast: true
+
+  # PHP extensions required by Composer
+  EXTENSIONS: pdo
 
 permissions:
   contents: read
 
 jobs:
-  build:
 
-    runs-on: ubuntu-latest
+  # PHPStan
+  quality:
+    name: "Validate Quality"
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
 
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php:
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Validate composer.json and composer.lock
-      run: composer validate --strict
+      - name: "Setup PHP"
+        uses: shivammathur/setup-php@2.35.3
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ env.EXTENSIONS }}
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v3
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
+      - name: "Install development dependencies with Composer"
+        uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--prefer-dist"
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
+      - name: "PHPStan"
+        run: |
+          composer stan
 
-    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
-    # Docs: https://getcomposer.org/doc/articles/scripts.md
+  unit-tests:
+    needs: quality
 
-    # - name: Run test suite
-    #   run: composer run-script test
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+
+    name: Unit tests / PHP-${{ matrix.php }}
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        php:
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
+    steps:
+      - name: "Setup PHP"
+        uses: shivammathur/setup-php@2.35.3
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ env.EXTENSIONS }}
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Install development dependencies with Composer"
+        uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--prefer-dist"
+
+      - name: "Run Unit Tests"
+        if: always()
+        run: |
+          composer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
           - '8.3'
           - '8.4'
     steps:
+      - uses: actions/checkout@v4
+
       - name: "Setup PHP"
         uses: shivammathur/setup-php@2.35.3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       fail-fast: true
       matrix:
         php:
+          - '8.0'
           - '8.1'
           - '8.2'
           - '8.3'
@@ -72,6 +73,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - '8.0'
           - '8.1'
           - '8.2'
           - '8.3'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /composer.lock
 /vendor/*
 /.phpunit.result.cache
+/.bash_history
+.composer

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "atlas/pdo",
     "type": "library",
-    "version": "2.0.0",
     "description": "Provides a PDO instance decorator with convenience methods, and a connection manager.",
     "keywords": [
         "pdo",
@@ -18,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.0",
         "ext-pdo": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "pds/skeleton": "^1.0",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^2.1"
     },
     "autoload-dev": {
@@ -36,7 +36,7 @@
         }
     },
     "scripts": {
-        "test": "./vendor/bin/phpunit --display-all-issues",
+        "test": "./vendor/bin/phpunit",
         "stan": "./vendor/bin/phpstan analyze -c phpstan.neon src"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "atlas/pdo",
     "type": "library",
+    "version": "2.0.0",
     "description": "Provides a PDO instance decorator with convenience methods, and a connection manager.",
     "keywords": [
         "pdo",
@@ -17,7 +18,8 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^8.1",
+        "ext-pdo": "*"
     },
     "autoload": {
         "psr-4": {
@@ -26,8 +28,8 @@
     },
     "require-dev": {
         "pds/skeleton": "^1.0",
-        "phpunit/phpunit": "^9.0",
-        "phpstan/phpstan": "^0.12.82"
+        "phpunit/phpunit": "^10.5",
+        "phpstan/phpstan": "^2.1"
     },
     "autoload-dev": {
         "psr-4": {
@@ -35,7 +37,7 @@
         }
     },
     "scripts": {
-        "test": "./vendor/bin/phpunit",
+        "test": "./vendor/bin/phpunit --display-all-issues",
         "stan": "./vendor/bin/phpstan analyze -c phpstan.neon src"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,16 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./phpunit.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./phpunit.php"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         cacheDirectory=".phpunit.result.cache">
   <testsuites>
     <testsuite name="atlas/pdo">
       <directory>./tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,15 @@
 <?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="./phpunit.php"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         cacheDirectory=".phpunit.result.cache">
-  <testsuites>
-    <testsuite name="atlas/pdo">
-      <directory>./tests</directory>
-    </testsuite>
-  </testsuites>
-  <source>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </source>
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="atlas/pdo">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -25,23 +25,10 @@ use PDOStatement;
  * @method string quote(mixed $string, int $parameterType = PDO::PARAM_STR)
  * @method mixed setAttribute(int $attribute, mixed $value)
  *
- * @phpstan-type dsnArgs array{
- *      dsn: string,
- *      username?: string,
- *      password?: string,
- *      options?: array<int, mixed>
- *  }
- *
- * @phpstan-type logEntryType array{
- *      start: float,
- *      finish: ?float,
- *      duration: ?float,
- *      performed: ?bool,
- *      statement: ?string,
- *      values: array<array-key, mixed>,
- *      trace: ?string,
-*       connection?: string
- * }
+ * @phpstan-import-type dsn_args_array from PdoCustomTypes
+ * @phpstan-import-type log_entry_array from PdoCustomTypes
+ * @phpstan-import-type fetch_assoc_array from PdoCustomTypes
+ * @phpstan-import-type fetch_string_mixed_array from PdoCustomTypes
  */
 class Connection
 {
@@ -51,7 +38,7 @@ class Connection
             return new static($args[0]);
         }
 
-        /** @var dsnArgs $args */
+        /** @var dsn_args_array $args */
         return new static(new PDO(...$args));
     }
 
@@ -75,7 +62,7 @@ class Connection
 
     public function __construct(protected PDO $pdo)
     {
-        $this->persistent = (bool)$this->pdo->getAttribute(PDO::ATTR_PERSISTENT);
+        $this->persistent = (bool) $this->pdo->getAttribute(PDO::ATTR_PERSISTENT);
     }
 
     public function __call(
@@ -153,7 +140,7 @@ class Connection
             $sth = PersistentLoggedStatement::new(
                 $sth,
                 function (array $entry) : void {
-                    /** @var logEntryType $entry */
+                    /** @var log_entry_array $entry */
                     $this->addLogEntry($entry);
                 },
                 $this->newLogEntry()
@@ -178,6 +165,13 @@ class Connection
         return $sth;
     }
 
+    /**
+     * @param PDOStatement $sth
+     * @param int|string   $name
+     * @param mixed        $args
+     *
+     * @return void
+     */
     protected function performBind(
         PDOStatement $sth,
         mixed $name,
@@ -190,7 +184,6 @@ class Connection
         }
 
         if (! is_array($args)) {
-            /** @var int|string $name */
             $sth->bindValue($name, $args);
             return;
         }
@@ -201,7 +194,6 @@ class Connection
             $args[0] = $args[0] ? '1' : '0';
         }
 
-        /** @var int|string $name */
         $sth->bindValue($name, ...$args);
     }
 
@@ -286,10 +278,10 @@ class Connection
     /**
      * @template T of object
      * *
-     * @param string          $statement
-     * @param array           $values
-     * @param class-string<T> $class
-     * @param array<mixed>    ...$args
+     * @param string              $statement
+     * @param array               $values
+     * @param class-string<T>     $class
+     * @param callable|int|string ...$args
      *
      * @return array|false
      */
@@ -301,17 +293,22 @@ class Connection
     ) : array|false
     {
         $sth = $this->perform($statement, $values);
-        /** @var array<array-key, callable|int|string> $args */
         return $sth->fetchAll(PDO::FETCH_CLASS, $class, ...$args);
     }
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     *
+     * @return fetch_assoc_array|false
+     */
     public function fetchOne(
         string $statement,
         array $values = []
     ) : array|false
     {
         $sth = $this->perform($statement, $values);
-        /** @var array<array-key, mixed> $result */
+        /** @var fetch_assoc_array $result */
         $result = $sth->fetch(PDO::FETCH_ASSOC);
 
         return $result;
@@ -358,7 +355,7 @@ class Connection
         $sth = $this->perform($statement, $values);
 
         while ($row = $sth->fetch(PDO::FETCH_UNIQUE)) {
-            /** @var array<string, mixed> $row */
+            /** @var fetch_string_mixed_array $row */
             $key = array_shift($row);
             yield $key => $row;
         }
@@ -437,7 +434,7 @@ class Connection
             LoggedStatement::CLASS,
             [
                 function (array $entry) : void {
-                    /** @var logEntryType $entry */
+                    /** @var log_entry_array $entry */
                     $this->addLogEntry($entry);
                 },
                 $this->newLogEntry()
@@ -458,7 +455,7 @@ class Connection
     /**
      * @param string|null $statement
      *
-     * @return logEntryType
+     * @return log_entry_array
      */
     protected function newLogEntry(?string $statement = null) : array
     {
@@ -474,7 +471,7 @@ class Connection
     }
 
     /**
-     * @param logEntryType $entry
+     * @param log_entry_array $entry
      *
      * @return void
      */

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -21,7 +21,7 @@ use PDOStatement;
  * @method array errorInfo()
  * @method mixed getAttribute(int $attribute)
  * @method bool inTransaction()
- * @method string lastInsertId(string $name = null)
+ * @method string lastInsertId(?string $name = null)
  * @method string quote(mixed $string, int $parameterType = PDO::PARAM_STR)
  * @method mixed setAttribute(int $attribute, mixed $value)
  *

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -24,18 +24,47 @@ use PDOStatement;
  * @method string lastInsertId(string $name = null)
  * @method string quote(mixed $string, int $parameterType = PDO::PARAM_STR)
  * @method mixed setAttribute(int $attribute, mixed $value)
+ *
+ * @phpstan-type dsnArgs array{
+ *      dsn: string,
+ *      username?: string,
+ *      password?: string,
+ *      options?: array<int, mixed>
+ *  }
+ *
+ * @phpstan-type logEntry array{
+ *      start: float,
+ *      finish: ?float,
+ *      duration: ?float,
+ *      performed: ?bool,
+ *      statement: ?string,
+ *      values: array<array-key, mixed>,
+ *      trace: ?string,
+*       connection?: string
+ * }
  */
 class Connection
 {
+    /**
+     * @param mixed ...$args
+     *
+     * @return Connection
+     */
     static public function new(mixed ...$args) : Connection
     {
         if ($args[0] instanceof PDO) {
             return new static($args[0]);
         }
 
+        /** @var dsnArgs $args */
         return new static(new PDO(...$args));
     }
 
+    /**
+     * @param mixed ...$args
+     *
+     * @return callable
+     */
     static public function factory(mixed ...$args) : callable
     {
         return function () use ($args) {
@@ -43,19 +72,40 @@ class Connection
         };
     }
 
+    /**
+     * @var bool
+     */
     protected bool $logQueries = false;
 
+    /**
+     * @var bool
+     */
     protected bool $persistent = false;
 
+    /**
+     * @var array
+     */
     protected array $queries = [];
 
+    /**
+     * @var callable|null
+     */
     protected mixed /* callable */ $queryLogger = null;
 
+    /**
+     * @param PDO $pdo
+     */
     public function __construct(protected PDO $pdo)
     {
-        $this->persistent = $this->pdo->getAttribute(PDO::ATTR_PERSISTENT);
+        $this->persistent = (bool)$this->pdo->getAttribute(PDO::ATTR_PERSISTENT);
     }
 
+    /**
+     * @param string $method
+     * @param array  $arguments
+     *
+     * @return mixed
+     */
     public function __call(
         string $method,
         array $arguments
@@ -64,11 +114,20 @@ class Connection
         return $this->pdo->$method(...$arguments);
     }
 
+    /**
+     * @return string
+     */
     public function getDriverName() : string
     {
-        return $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+        /** @var string $driverName */
+        $driverName = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        return $driverName;
     }
 
+    /**
+     * @return PDO
+     */
     public function getPdo() : PDO
     {
         return $this->pdo;
@@ -76,6 +135,9 @@ class Connection
 
     /* Transactions */
 
+    /**
+     * @return bool
+     */
     public function beginTransaction() : bool
     {
         $entry = $this->newLogEntry(__METHOD__);
@@ -84,6 +146,9 @@ class Connection
         return $result;
     }
 
+    /**
+     * @return bool
+     */
     public function commit() : bool
     {
         $entry = $this->newLogEntry(__METHOD__);
@@ -99,6 +164,9 @@ class Connection
         return $result;
     }
 
+    /**
+     * @return bool
+     */
     public function rollBack() : bool
     {
         $entry = $this->newLogEntry(__METHOD__);
@@ -109,6 +177,11 @@ class Connection
 
     /* Queries */
 
+    /**
+     * @param string $statement
+     *
+     * @return int|false
+     */
     public function exec(string $statement) : int|false
     {
         $entry = $this->newLogEntry($statement);
@@ -117,6 +190,12 @@ class Connection
         return $rowCount;
     }
 
+    /**
+     * @param string $statement
+     * @param array  $driverOptions
+     *
+     * @return PDOStatement
+     */
     public function prepare(
         string $statement,
         array $driverOptions = []
@@ -128,6 +207,7 @@ class Connection
             $sth = PersistentLoggedStatement::new(
                 $sth,
                 function (array $entry) : void {
+                    /** @var logEntry $entry */
                     $this->addLogEntry($entry);
                 },
                 $this->newLogEntry()
@@ -137,6 +217,12 @@ class Connection
         return $sth;
     }
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     *
+     * @return PDOStatement
+     */
     public function perform(
         string $statement,
         array $values = []
@@ -152,6 +238,13 @@ class Connection
         return $sth;
     }
 
+    /**
+     * @param PDOStatement $sth
+     * @param mixed        $name
+     * @param mixed        $args
+     *
+     * @return void
+     */
     protected function performBind(
         PDOStatement $sth,
         mixed $name,
@@ -164,6 +257,7 @@ class Connection
         }
 
         if (! is_array($args)) {
+            /** @var int|string $name */
             $sth->bindValue($name, $args);
             return;
         }
@@ -174,9 +268,16 @@ class Connection
             $args[0] = $args[0] ? '1' : '0';
         }
 
+        /** @var int|string $name */
         $sth->bindValue($name, ...$args);
     }
 
+    /**
+     * @param string $statement
+     * @param mixed  ...$fetch
+     *
+     * @return PDOStatement|false
+     */
     public function query(string $statement, mixed ...$fetch) : PDOStatement|false
     {
         $entry = $this->newLogEntry($statement);
@@ -187,6 +288,12 @@ class Connection
 
     /* Fetching */
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     *
+     * @return int
+     */
     public function fetchAffected(
         string $statement,
         array $values = []
@@ -196,6 +303,12 @@ class Connection
         return $sth->rowCount();
     }
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     *
+     * @return array|false
+     */
     public function fetchAll(
         string $statement,
         array $values = []
@@ -205,6 +318,13 @@ class Connection
         return $sth->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     * @param int    $column
+     *
+     * @return array|false
+     */
     public function fetchColumn(
         string $statement,
         array $values = [],
@@ -215,6 +335,13 @@ class Connection
         return $sth->fetchAll(PDO::FETCH_COLUMN, $column);
     }
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     * @param int    $style
+     *
+     * @return array|false
+     */
     public function fetchGroup(
         string $statement,
         array $values = [],
@@ -225,6 +352,12 @@ class Connection
         return $sth->fetchAll(PDO::FETCH_GROUP | $style);
     }
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     *
+     * @return array|false
+     */
     public function fetchKeyPair(
         string $statement,
         array $values = []
@@ -234,6 +367,16 @@ class Connection
         return $sth->fetchAll(PDO::FETCH_KEY_PAIR);
     }
 
+    /**
+     * @template T of object
+     *
+     * @param string          $statement
+     * @param array           $values
+     * @param class-string<T> $class
+     * @param array<mixed>    ...$args
+     *
+     * @return T|false
+     */
     public function fetchObject(
         string $statement,
         array $values = [],
@@ -245,6 +388,16 @@ class Connection
         return $sth->fetchObject($class, ...$args);
     }
 
+    /**
+     * @template T of object
+     * *
+     * @param string          $statement
+     * @param array           $values
+     * @param class-string<T> $class
+     * @param array<mixed>    ...$args
+     *
+     * @return array|false
+     */
     public function fetchObjects(
         string $statement,
         array $values = [],
@@ -253,18 +406,35 @@ class Connection
     ) : array|false
     {
         $sth = $this->perform($statement, $values);
+        /** @var array<array-key, callable|int|string> $args */
         return $sth->fetchAll(PDO::FETCH_CLASS, $class, ...$args);
     }
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     *
+     * @return array|false
+     */
     public function fetchOne(
         string $statement,
         array $values = []
     ) : array|false
     {
-        $sth = $this->perform($statement, $values);
-        return $sth->fetch(PDO::FETCH_ASSOC);
+        $sth    = $this->perform($statement, $values);
+        /** @var array<array-key, mixed> $result */
+        $result = $sth->fetch(PDO::FETCH_ASSOC);
+
+        return $result;
     }
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     * @param int    $column
+     *
+     * @return mixed
+     */
     public function fetchValue(
         string $statement,
         array $values = [],
@@ -275,6 +445,12 @@ class Connection
         return $sth->fetchColumn($column);
     }
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     *
+     * @return array|false
+     */
     public function fetchUnique(
         string $statement,
         array $values = []
@@ -286,6 +462,12 @@ class Connection
 
     /* Yielding */
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     *
+     * @return Generator
+     */
     public function yieldAll(
         string $statement,
         array $values = []
@@ -298,6 +480,12 @@ class Connection
         }
     }
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     *
+     * @return Generator
+     */
     public function yieldUnique(
         string $statement,
         array $values = []
@@ -306,11 +494,19 @@ class Connection
         $sth = $this->perform($statement, $values);
 
         while ($row = $sth->fetch(PDO::FETCH_UNIQUE)) {
+            /** @var array<string, mixed> $row */
             $key = array_shift($row);
             yield $key => $row;
         }
     }
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     * @param int    $column
+     *
+     * @return Generator
+     */
     public function yieldColumn(
         string $statement,
         array $values = [],
@@ -320,10 +516,21 @@ class Connection
         $sth = $this->perform($statement, $values);
 
         while ($row = $sth->fetch(PDO::FETCH_NUM)) {
+            /** @var array<int, mixed> $row */
             yield $row[$column];
         }
     }
 
+    /**
+     * @template T of object
+     *
+     * @param string          $statement
+     * @param array           $values
+     * @param class-string<T> $class
+     * @param array<mixed>    ...$args
+     *
+     * @return Generator
+     */
     public function yieldObjects(
         string $statement,
         array $values = [],
@@ -338,6 +545,12 @@ class Connection
         }
     }
 
+    /**
+     * @param string $statement
+     * @param array  $values
+     *
+     * @return Generator
+     */
     public function yieldKeyPair(
         string $statement,
         array $values = []
@@ -346,12 +559,18 @@ class Connection
         $sth = $this->perform($statement, $values);
 
         while ($row = $sth->fetch(PDO::FETCH_NUM)) {
+            /** @var array<int, mixed> $row */
             yield $row[0] => $row[1];
         }
     }
 
     /* Logging */
 
+    /**
+     * @param bool $logQueries
+     *
+     * @return void
+     */
     public function logQueries(bool $logQueries = true) : void
     {
         $this->logQueries = $logQueries;
@@ -372,6 +591,7 @@ class Connection
             LoggedStatement::CLASS,
             [
                 function (array $entry) : void {
+                    /** @var logEntry $entry */
                     $this->addLogEntry($entry);
                 },
                 $this->newLogEntry()
@@ -379,29 +599,47 @@ class Connection
         ]);
     }
 
+    /**
+     * @return array
+     */
     public function getQueries() : array
     {
         return $this->queries;
     }
 
+    /**
+     * @param callable $queryLogger
+     *
+     * @return void
+     */
     public function setQueryLogger(callable $queryLogger) : void
     {
         $this->queryLogger = $queryLogger;
     }
 
+    /**
+     * @param string|null $statement
+     *
+     * @return logEntry
+     */
     protected function newLogEntry(string $statement = null) : array
     {
         return [
-            'start' => microtime(true),
-            'finish' => null,
-            'duration' => null,
+            'start'     => microtime(true),
+            'finish'    => null,
+            'duration'  => null,
             'performed' => null,
             'statement' => $statement,
-            'values' => [],
-            'trace' => null,
+            'values'    => [],
+            'trace'     => null,
         ];
     }
 
+    /**
+     * @param logEntry $entry
+     *
+     * @return void
+     */
     protected function addLogEntry(array $entry) : void
     {
         if (! $this->logQueries) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -45,11 +45,6 @@ use PDOStatement;
  */
 class Connection
 {
-    /**
-     * @param mixed ...$args
-     *
-     * @return Connection
-     */
     static public function new(mixed ...$args) : Connection
     {
         if ($args[0] instanceof PDO) {
@@ -60,11 +55,6 @@ class Connection
         return new static(new PDO(...$args));
     }
 
-    /**
-     * @param mixed ...$args
-     *
-     * @return callable
-     */
     static public function factory(mixed ...$args) : callable
     {
         return function () use ($args) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -622,7 +622,7 @@ class Connection
      *
      * @return logEntry
      */
-    protected function newLogEntry(string $statement = null) : array
+    protected function newLogEntry(?string $statement = null) : array
     {
         return [
             'start'     => microtime(true),

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -32,7 +32,7 @@ use PDOStatement;
  *      options?: array<int, mixed>
  *  }
  *
- * @phpstan-type logEntry array{
+ * @phpstan-type logEntryType array{
  *      start: float,
  *      finish: ?float,
  *      duration: ?float,
@@ -71,7 +71,7 @@ class Connection
     /**
      * @var callable|null
      */
-    protected mixed /* callable */ $queryLogger = null;
+    protected mixed $queryLogger = null;
 
     public function __construct(protected PDO $pdo)
     {
@@ -153,7 +153,7 @@ class Connection
             $sth = PersistentLoggedStatement::new(
                 $sth,
                 function (array $entry) : void {
-                    /** @var logEntry $entry */
+                    /** @var logEntryType $entry */
                     $this->addLogEntry($entry);
                 },
                 $this->newLogEntry()
@@ -310,7 +310,7 @@ class Connection
         array $values = []
     ) : array|false
     {
-        $sth    = $this->perform($statement, $values);
+        $sth = $this->perform($statement, $values);
         /** @var array<array-key, mixed> $result */
         $result = $sth->fetch(PDO::FETCH_ASSOC);
 
@@ -437,7 +437,7 @@ class Connection
             LoggedStatement::CLASS,
             [
                 function (array $entry) : void {
-                    /** @var logEntry $entry */
+                    /** @var logEntryType $entry */
                     $this->addLogEntry($entry);
                 },
                 $this->newLogEntry()
@@ -458,23 +458,23 @@ class Connection
     /**
      * @param string|null $statement
      *
-     * @return logEntry
+     * @return logEntryType
      */
     protected function newLogEntry(?string $statement = null) : array
     {
         return [
-            'start'     => microtime(true),
-            'finish'    => null,
-            'duration'  => null,
+            'start' => microtime(true),
+            'finish' => null,
+            'duration' => null,
             'performed' => null,
             'statement' => $statement,
-            'values'    => [],
-            'trace'     => null,
+            'values' => [],
+            'trace' => null,
         ];
     }
 
     /**
-     * @param logEntry $entry
+     * @param logEntryType $entry
      *
      * @return void
      */

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -62,19 +62,10 @@ class Connection
         };
     }
 
-    /**
-     * @var bool
-     */
     protected bool $logQueries = false;
 
-    /**
-     * @var bool
-     */
     protected bool $persistent = false;
 
-    /**
-     * @var array
-     */
     protected array $queries = [];
 
     /**
@@ -82,20 +73,11 @@ class Connection
      */
     protected mixed /* callable */ $queryLogger = null;
 
-    /**
-     * @param PDO $pdo
-     */
     public function __construct(protected PDO $pdo)
     {
         $this->persistent = (bool)$this->pdo->getAttribute(PDO::ATTR_PERSISTENT);
     }
 
-    /**
-     * @param string $method
-     * @param array  $arguments
-     *
-     * @return mixed
-     */
     public function __call(
         string $method,
         array $arguments
@@ -104,9 +86,6 @@ class Connection
         return $this->pdo->$method(...$arguments);
     }
 
-    /**
-     * @return string
-     */
     public function getDriverName() : string
     {
         /** @var string $driverName */
@@ -115,9 +94,6 @@ class Connection
         return $driverName;
     }
 
-    /**
-     * @return PDO
-     */
     public function getPdo() : PDO
     {
         return $this->pdo;
@@ -125,9 +101,6 @@ class Connection
 
     /* Transactions */
 
-    /**
-     * @return bool
-     */
     public function beginTransaction() : bool
     {
         $entry = $this->newLogEntry(__METHOD__);
@@ -136,9 +109,6 @@ class Connection
         return $result;
     }
 
-    /**
-     * @return bool
-     */
     public function commit() : bool
     {
         $entry = $this->newLogEntry(__METHOD__);
@@ -154,9 +124,6 @@ class Connection
         return $result;
     }
 
-    /**
-     * @return bool
-     */
     public function rollBack() : bool
     {
         $entry = $this->newLogEntry(__METHOD__);
@@ -167,11 +134,6 @@ class Connection
 
     /* Queries */
 
-    /**
-     * @param string $statement
-     *
-     * @return int|false
-     */
     public function exec(string $statement) : int|false
     {
         $entry = $this->newLogEntry($statement);
@@ -180,12 +142,6 @@ class Connection
         return $rowCount;
     }
 
-    /**
-     * @param string $statement
-     * @param array  $driverOptions
-     *
-     * @return PDOStatement
-     */
     public function prepare(
         string $statement,
         array $driverOptions = []
@@ -207,12 +163,6 @@ class Connection
         return $sth;
     }
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     *
-     * @return PDOStatement
-     */
     public function perform(
         string $statement,
         array $values = []
@@ -228,13 +178,6 @@ class Connection
         return $sth;
     }
 
-    /**
-     * @param PDOStatement $sth
-     * @param mixed        $name
-     * @param mixed        $args
-     *
-     * @return void
-     */
     protected function performBind(
         PDOStatement $sth,
         mixed $name,
@@ -262,12 +205,6 @@ class Connection
         $sth->bindValue($name, ...$args);
     }
 
-    /**
-     * @param string $statement
-     * @param mixed  ...$fetch
-     *
-     * @return PDOStatement|false
-     */
     public function query(string $statement, mixed ...$fetch) : PDOStatement|false
     {
         $entry = $this->newLogEntry($statement);
@@ -278,12 +215,6 @@ class Connection
 
     /* Fetching */
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     *
-     * @return int
-     */
     public function fetchAffected(
         string $statement,
         array $values = []
@@ -293,12 +224,6 @@ class Connection
         return $sth->rowCount();
     }
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     *
-     * @return array|false
-     */
     public function fetchAll(
         string $statement,
         array $values = []
@@ -308,13 +233,6 @@ class Connection
         return $sth->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     * @param int    $column
-     *
-     * @return array|false
-     */
     public function fetchColumn(
         string $statement,
         array $values = [],
@@ -325,13 +243,6 @@ class Connection
         return $sth->fetchAll(PDO::FETCH_COLUMN, $column);
     }
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     * @param int    $style
-     *
-     * @return array|false
-     */
     public function fetchGroup(
         string $statement,
         array $values = [],
@@ -342,12 +253,6 @@ class Connection
         return $sth->fetchAll(PDO::FETCH_GROUP | $style);
     }
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     *
-     * @return array|false
-     */
     public function fetchKeyPair(
         string $statement,
         array $values = []
@@ -400,12 +305,6 @@ class Connection
         return $sth->fetchAll(PDO::FETCH_CLASS, $class, ...$args);
     }
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     *
-     * @return array|false
-     */
     public function fetchOne(
         string $statement,
         array $values = []
@@ -418,13 +317,6 @@ class Connection
         return $result;
     }
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     * @param int    $column
-     *
-     * @return mixed
-     */
     public function fetchValue(
         string $statement,
         array $values = [],
@@ -435,12 +327,6 @@ class Connection
         return $sth->fetchColumn($column);
     }
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     *
-     * @return array|false
-     */
     public function fetchUnique(
         string $statement,
         array $values = []
@@ -452,12 +338,6 @@ class Connection
 
     /* Yielding */
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     *
-     * @return Generator
-     */
     public function yieldAll(
         string $statement,
         array $values = []
@@ -470,12 +350,6 @@ class Connection
         }
     }
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     *
-     * @return Generator
-     */
     public function yieldUnique(
         string $statement,
         array $values = []
@@ -490,13 +364,6 @@ class Connection
         }
     }
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     * @param int    $column
-     *
-     * @return Generator
-     */
     public function yieldColumn(
         string $statement,
         array $values = [],
@@ -535,12 +402,6 @@ class Connection
         }
     }
 
-    /**
-     * @param string $statement
-     * @param array  $values
-     *
-     * @return Generator
-     */
     public function yieldKeyPair(
         string $statement,
         array $values = []
@@ -556,11 +417,6 @@ class Connection
 
     /* Logging */
 
-    /**
-     * @param bool $logQueries
-     *
-     * @return void
-     */
     public function logQueries(bool $logQueries = true) : void
     {
         $this->logQueries = $logQueries;
@@ -589,19 +445,11 @@ class Connection
         ]);
     }
 
-    /**
-     * @return array
-     */
     public function getQueries() : array
     {
         return $this->queries;
     }
 
-    /**
-     * @param callable $queryLogger
-     *
-     * @return void
-     */
     public function setQueryLogger(callable $queryLogger) : void
     {
         $this->queryLogger = $queryLogger;

--- a/src/ConnectionLocator.php
+++ b/src/ConnectionLocator.php
@@ -238,10 +238,6 @@ class ConnectionLocator
         string $name
     ) : Connection
     {
-        if (strtolower($type) === 'default') {
-            throw Exception::connectionNotFound($type, $name);
-        }
-
         $prop = strtolower($type) . 'Factories';
         /** @var array<string, callable> $factories */
         $factories = $this->$prop;

--- a/src/ConnectionLocator.php
+++ b/src/ConnectionLocator.php
@@ -11,12 +11,8 @@ declare(strict_types=1);
 namespace Atlas\Pdo;
 
 /**
- * @phpstan-type connectionStore array{
- *      DEFAULT: ?Connection,
- *      READ: array<string, ?Connection>,
- *      WRITE: array<string, ?Connection>
- * }
- * @phpstan-import-type logEntryType from Connection
+ * @phpstan-import-type connection_store_array from PdoCustomTypes
+ * @phpstan-import-type log_entry_array from PdoCustomTypes
  */
 class ConnectionLocator
 {
@@ -49,7 +45,7 @@ class ConnectionLocator
     }
 
     /**
-     * @var connectionStore
+     * @var connection_store_array
      */
     protected array $instances = [
         self::DEFAULT => null,
@@ -66,7 +62,7 @@ class ConnectionLocator
     protected bool $logQueries = false;
 
     /**
-     * @var logEntryType[]
+     * @var log_entry_array[]
      */
     protected array $queries = [];
 
@@ -205,7 +201,7 @@ class ConnectionLocator
         $connection = $factory();
 
         $queryLogger = function (array $entry) use ($label) : void {
-            /** @var logEntryType $entry */
+            /** @var log_entry_array $entry */
             $entry = ['connection' => $label] + $entry;
             $this->addLogEntry($entry);
         };
@@ -258,7 +254,7 @@ class ConnectionLocator
     }
 
     /**
-     * @return logEntryType[]
+     * @return log_entry_array[]
      */
     public function getQueries() : array
     {
@@ -271,7 +267,7 @@ class ConnectionLocator
     }
 
     /**
-     * @param logEntryType $entry
+     * @param log_entry_array $entry
      *
      * @return void
      */

--- a/src/ConnectionLocator.php
+++ b/src/ConnectionLocator.php
@@ -16,7 +16,7 @@ namespace Atlas\Pdo;
  *      READ: array<string, ?Connection>,
  *      WRITE: array<string, ?Connection>
  * }
- * @phpstan-import-type logEntry from Connection
+ * @phpstan-import-type logEntryType from Connection
  */
 class ConnectionLocator
 {
@@ -53,8 +53,8 @@ class ConnectionLocator
      */
     protected array $instances = [
         self::DEFAULT => null,
-        self::READ    => [],
-        self::WRITE   => [],
+        self::READ => [],
+        self::WRITE => [],
     ];
 
     protected ?Connection $read = null;
@@ -66,7 +66,7 @@ class ConnectionLocator
     protected bool $logQueries = false;
 
     /**
-     * @var logEntry[]
+     * @var logEntryType[]
      */
     protected array $queries = [];
 
@@ -205,7 +205,7 @@ class ConnectionLocator
         $connection = $factory();
 
         $queryLogger = function (array $entry) use ($label) : void {
-            /** @var logEntry $entry */
+            /** @var logEntryType $entry */
             $entry = ['connection' => $label] + $entry;
             $this->addLogEntry($entry);
         };
@@ -258,7 +258,7 @@ class ConnectionLocator
     }
 
     /**
-     * @return logEntry[]
+     * @return logEntryType[]
      */
     public function getQueries() : array
     {
@@ -271,7 +271,7 @@ class ConnectionLocator
     }
 
     /**
-     * @param logEntry $entry
+     * @param logEntryType $entry
      *
      * @return void
      */

--- a/src/ConnectionLocator.php
+++ b/src/ConnectionLocator.php
@@ -10,14 +10,40 @@ declare(strict_types=1);
 
 namespace Atlas\Pdo;
 
+use function stat;
+use function strtolower;
+
+/**
+ * @phpstan-type connectionStore array{
+ *      DEFAULT: ?Connection,
+ *      READ: array<string, ?Connection>,
+ *      WRITE: array<string, ?Connection>
+ * }
+ * @phpstan-import-type logEntry from Connection
+ */
 class ConnectionLocator
 {
+    /**
+     * @var string
+     */
     public const DEFAULT = 'DEFAULT';
 
+    /**
+     * @var string
+     */
     public const READ = 'READ';
 
+    /**
+     * @var string
+     */
     public const WRITE = 'WRITE';
 
+    /**
+     * @param mixed $arg
+     * @param mixed ...$args
+     *
+     * @return static
+     */
     static public function new(mixed $arg, mixed ...$args) : static
     {
         if ($arg instanceof Connection) {
@@ -31,36 +57,73 @@ class ConnectionLocator
         return new static(Connection::factory($arg, ...$args));
     }
 
+    /**
+     * @var connectionStore
+     */
     protected array $instances = [
         self::DEFAULT => null,
-        self::READ => [],
-        self::WRITE => [],
+        self::READ    => [],
+        self::WRITE   => [],
     ];
 
+    /**
+     * @var Connection|null
+     */
     protected ?Connection $read = null;
 
+    /**
+     * @var Connection|null
+     */
     protected ?Connection $write = null;
 
+    /**
+     * @var bool
+     */
     protected bool $lockToWrite = false;
 
+    /**
+     * @var bool
+     */
     protected bool $logQueries = false;
 
+    /**
+     * @var logEntry[]
+     */
     protected array $queries = [];
 
+    /**
+     * @var callable|null
+     */
     protected mixed $queryLogger = null;
 
+    /**
+     * @param callable $defaultFactory
+     * @param array    $readFactories
+     * @param array    $writeFactories
+     */
     public function __construct(
-        protected mixed /* callable */ $defaultFactory = null,
+        protected mixed $defaultFactory = null,
         protected array $readFactories = [],
         protected array $writeFactories = []
     ) {
     }
 
+    /**
+     * @param callable $factory
+     *
+     * @return void
+     */
     public function setDefaultFactory(callable $factory) : void
     {
         $this->defaultFactory = $factory;
     }
 
+    /**
+     * @param string   $name
+     * @param callable $factory
+     *
+     * @return void
+     */
     public function setReadFactory(
         string $name,
         callable $factory
@@ -69,6 +132,12 @@ class ConnectionLocator
         $this->readFactories[$name] = $factory;
     }
 
+    /**
+     * @param string   $name
+     * @param callable $factory
+     *
+     * @return void
+     */
     public function setWriteFactory(
         string $name,
         callable $factory
@@ -77,18 +146,27 @@ class ConnectionLocator
         $this->writeFactories[$name] = $factory;
     }
 
+    /**
+     * @return Connection
+     */
     public function getDefault() : Connection
     {
-        if ($this->instances[static::DEFAULT] === null) {
-            $this->instances[static::DEFAULT] = $this->newConnection(
+        /** @var 'DEFAULT' $type */
+        $type = static::DEFAULT;
+
+        if ($this->instances[$type] === null) {
+            $this->instances[$type] = $this->newConnection(
                 $this->defaultFactory,
-                static::DEFAULT
+                $type
             );
         }
 
-        return $this->instances[static::DEFAULT];
+        return $this->instances[$type];
     }
 
+    /**
+     * @return Connection
+     */
     public function getRead() : Connection
     {
         if ($this->lockToWrite) {
@@ -105,6 +183,9 @@ class ConnectionLocator
         return $this->read;
     }
 
+    /**
+     * @return Connection
+     */
     public function getWrite() : Connection
     {
         if (! isset($this->write)) {
@@ -117,6 +198,13 @@ class ConnectionLocator
         return $this->write;
     }
 
+    /**
+     * @param string $type
+     * @param array  $factories
+     *
+     * @return Connection
+     * @throws Exception
+     */
     protected function getConnection(
         string $type,
         array $factories
@@ -127,24 +215,42 @@ class ConnectionLocator
         }
 
         if (! empty($this->instances[$type])) {
-            return reset($this->instances[$type]);
+            /** @var array<string, array<string, Connection>> $instances */
+            $instances = $this->instances;
+            /** @var Connection $connection */
+            $connection = reset($instances[$type]);
+
+            return $connection;
         }
 
         return $this->get($type, (string) array_rand($factories));
     }
 
+    /**
+     * @param string $type
+     * @param string $name
+     *
+     * @return Connection
+     * @throws Exception
+     */
     public function get(
         string $type,
         string $name
     ) : Connection
     {
+        if (strtolower($type) === 'default') {
+            throw Exception::connectionNotFound($type, $name);
+        }
+
         $prop = strtolower($type) . 'Factories';
+        /** @var array<string, callable> $factories */
         $factories = $this->$prop;
 
         if (! isset($factories[$name])) {
             throw Exception::connectionNotFound($type, $name);
         }
 
+        /** @var 'READ'|'WRITE' $type */
         if (! isset($this->instances[$type][$name])) {
             $this->instances[$type][$name] = $this->newConnection(
                 $factories[$name],
@@ -155,14 +261,22 @@ class ConnectionLocator
         return $this->instances[$type][$name];
     }
 
+    /**
+     * @param callable $factory
+     * @param string   $label
+     *
+     * @return Connection
+     */
     protected function newConnection(
         callable $factory,
         string $label
     ) : Connection
     {
+        /** @var Connection $connection */
         $connection = $factory();
 
         $queryLogger = function (array $entry) use ($label) : void {
+            /** @var logEntry $entry */
             $entry = ['connection' => $label] + $entry;
             $this->addLogEntry($entry);
         };
@@ -173,36 +287,59 @@ class ConnectionLocator
         return $connection;
     }
 
+    /**
+     * @return bool
+     */
     public function hasRead() : bool
     {
         return isset($this->read);
     }
 
+    /**
+     * @return bool
+     */
     public function hasWrite() : bool
     {
         return isset($this->write);
     }
 
+    /**
+     * @param bool $lockToWrite
+     *
+     * @return void
+     */
     public function lockToWrite(bool $lockToWrite = true) : void
     {
         $this->lockToWrite = $lockToWrite;
     }
 
+    /**
+     * @return bool
+     */
     public function isLockedToWrite() : bool
     {
         return $this->lockToWrite;
     }
 
+    /**
+     * @param bool $logQueries
+     *
+     * @return void
+     */
     public function logQueries(bool $logQueries = true) : void
     {
-        if ($this->instances[static::DEFAULT] !== null) {
-            $this->instances[static::DEFAULT]->logQueries($logQueries);
+        /** @var Connection|null $defaultConnection */
+        $defaultConnection = $this->instances[static::DEFAULT] ?? null;
+        if ($defaultConnection !== null) {
+            $defaultConnection->logQueries($logQueries);
         }
 
         $types = [static::READ, static::WRITE];
 
         foreach ($types as $type) {
-            foreach ($this->instances[$type] as $connection) {
+            /** @var array<string, Connection> $instances */
+            $instances = $this->instances[$type];
+            foreach ($instances as $connection) {
                 $connection->logQueries($logQueries);
             }
         }
@@ -210,20 +347,35 @@ class ConnectionLocator
         $this->logQueries = $logQueries;
     }
 
+    /**
+     * @return logEntry[]
+     */
     public function getQueries() : array
     {
         return $this->queries;
     }
 
+    /**
+     * @param callable $queryLogger
+     *
+     * @return void
+     */
     public function setQueryLogger(callable $queryLogger) : void
     {
         $this->queryLogger = $queryLogger;
     }
 
+    /**
+     * @param logEntry $entry
+     *
+     * @return void
+     */
     protected function addLogEntry(array $entry) : void
     {
-        if ($this->queryLogger !== null) {
-            ($this->queryLogger)($entry);
+        /** @var callable|null $queryLogger */
+        $queryLogger = $this->queryLogger;
+        if ($queryLogger !== null) {
+            $queryLogger($entry);
         } else {
             $this->queries[] = $entry;
         }

--- a/src/ConnectionLocator.php
+++ b/src/ConnectionLocator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Atlas\Pdo;
 
 /**
+ * @phpstan-import-type connection_store_entry_array from PdoCustomTypes
  * @phpstan-import-type connection_store_array from PdoCustomTypes
  * @phpstan-import-type log_entry_array from PdoCustomTypes
  */
@@ -157,7 +158,7 @@ class ConnectionLocator
         }
 
         if (! empty($this->instances[$type])) {
-            /** @var array<string, array<string, Connection>> $instances */
+            /** @var array<string, connection_store_entry_array> $instances */
             $instances = $this->instances;
             /** @var Connection $connection */
             $connection = reset($instances[$type]);

--- a/src/ConnectionLocator.php
+++ b/src/ConnectionLocator.php
@@ -10,9 +10,6 @@ declare(strict_types=1);
 
 namespace Atlas\Pdo;
 
-use function stat;
-use function strtolower;
-
 /**
  * @phpstan-type connectionStore array{
  *      DEFAULT: ?Connection,
@@ -38,12 +35,6 @@ class ConnectionLocator
      */
     public const WRITE = 'WRITE';
 
-    /**
-     * @param mixed $arg
-     * @param mixed ...$args
-     *
-     * @return static
-     */
     static public function new(mixed $arg, mixed ...$args) : static
     {
         if ($arg instanceof Connection) {
@@ -66,24 +57,12 @@ class ConnectionLocator
         self::WRITE   => [],
     ];
 
-    /**
-     * @var Connection|null
-     */
     protected ?Connection $read = null;
 
-    /**
-     * @var Connection|null
-     */
     protected ?Connection $write = null;
 
-    /**
-     * @var bool
-     */
     protected bool $lockToWrite = false;
 
-    /**
-     * @var bool
-     */
     protected bool $logQueries = false;
 
     /**
@@ -108,22 +87,11 @@ class ConnectionLocator
     ) {
     }
 
-    /**
-     * @param callable $factory
-     *
-     * @return void
-     */
     public function setDefaultFactory(callable $factory) : void
     {
         $this->defaultFactory = $factory;
     }
 
-    /**
-     * @param string   $name
-     * @param callable $factory
-     *
-     * @return void
-     */
     public function setReadFactory(
         string $name,
         callable $factory
@@ -132,12 +100,6 @@ class ConnectionLocator
         $this->readFactories[$name] = $factory;
     }
 
-    /**
-     * @param string   $name
-     * @param callable $factory
-     *
-     * @return void
-     */
     public function setWriteFactory(
         string $name,
         callable $factory
@@ -146,9 +108,6 @@ class ConnectionLocator
         $this->writeFactories[$name] = $factory;
     }
 
-    /**
-     * @return Connection
-     */
     public function getDefault() : Connection
     {
         /** @var 'DEFAULT' $type */
@@ -164,9 +123,6 @@ class ConnectionLocator
         return $this->instances[$type];
     }
 
-    /**
-     * @return Connection
-     */
     public function getRead() : Connection
     {
         if ($this->lockToWrite) {
@@ -183,9 +139,6 @@ class ConnectionLocator
         return $this->read;
     }
 
-    /**
-     * @return Connection
-     */
     public function getWrite() : Connection
     {
         if (! isset($this->write)) {
@@ -198,13 +151,6 @@ class ConnectionLocator
         return $this->write;
     }
 
-    /**
-     * @param string $type
-     * @param array  $factories
-     *
-     * @return Connection
-     * @throws Exception
-     */
     protected function getConnection(
         string $type,
         array $factories
@@ -226,13 +172,6 @@ class ConnectionLocator
         return $this->get($type, (string) array_rand($factories));
     }
 
-    /**
-     * @param string $type
-     * @param string $name
-     *
-     * @return Connection
-     * @throws Exception
-     */
     public function get(
         string $type,
         string $name
@@ -257,12 +196,6 @@ class ConnectionLocator
         return $this->instances[$type][$name];
     }
 
-    /**
-     * @param callable $factory
-     * @param string   $label
-     *
-     * @return Connection
-     */
     protected function newConnection(
         callable $factory,
         string $label
@@ -283,45 +216,26 @@ class ConnectionLocator
         return $connection;
     }
 
-    /**
-     * @return bool
-     */
     public function hasRead() : bool
     {
         return isset($this->read);
     }
 
-    /**
-     * @return bool
-     */
     public function hasWrite() : bool
     {
         return isset($this->write);
     }
 
-    /**
-     * @param bool $lockToWrite
-     *
-     * @return void
-     */
     public function lockToWrite(bool $lockToWrite = true) : void
     {
         $this->lockToWrite = $lockToWrite;
     }
 
-    /**
-     * @return bool
-     */
     public function isLockedToWrite() : bool
     {
         return $this->lockToWrite;
     }
 
-    /**
-     * @param bool $logQueries
-     *
-     * @return void
-     */
     public function logQueries(bool $logQueries = true) : void
     {
         /** @var Connection|null $defaultConnection */
@@ -351,11 +265,6 @@ class ConnectionLocator
         return $this->queries;
     }
 
-    /**
-     * @param callable $queryLogger
-     *
-     * @return void
-     */
     public function setQueryLogger(callable $queryLogger) : void
     {
         $this->queryLogger = $queryLogger;

--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -42,14 +42,14 @@ class LoggedStatement extends PDOStatement
     }
 
     /**
-     * @param string|int $parameter
-     * @param mixed      $value
-     * @param int        $dataType
+     * @param mixed $parameter
+     * @param mixed $value
+     * @param int   $dataType
      *
      * @return bool
      */
     public function bindValue(
-        string|int $parameter,
+        mixed $parameter,
         mixed $value,
         int $dataType = PDO::PARAM_STR
     ) : bool

--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -45,7 +45,7 @@ class LoggedStatement extends PDOStatement
         /** @var int|string $parameter */
         $result = parent::bindValue($parameter, $value, $dataType);
 
-        if ($result && $this->logEntry !== null) {
+        if ($result && !empty($this->logEntry)) {
             $this->logEntry['values'][$parameter] = $value;
         }
 

--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -14,13 +14,13 @@ use PDO;
 use PDOStatement;
 
 /**
- * @phpstan-import-type  logEntryType from Connection
+ * @phpstan-import-type  log_entry_array from PdoCustomTypes
  */
 class LoggedStatement extends PDOStatement
 {
     /**
-     * @param callable     $queryLogger
-     * @param logEntryType $logEntry
+     * @param callable             $queryLogger
+     * @param log_entry_array $logEntry
      */
     protected function __construct(
         protected mixed $queryLogger,

--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -29,11 +29,6 @@ class LoggedStatement extends PDOStatement
         $this->logEntry['statement'] = $this->queryString;
     }
 
-    /**
-     * @param array|null $inputParameters
-     *
-     * @return bool
-     */
     public function execute(?array $inputParameters = null) : bool
     {
         $result = parent::execute($inputParameters);
@@ -41,13 +36,6 @@ class LoggedStatement extends PDOStatement
         return $result;
     }
 
-    /**
-     * @param mixed $parameter
-     * @param mixed $value
-     * @param int   $dataType
-     *
-     * @return bool
-     */
     public function bindValue(
         mixed $parameter,
         mixed $value,
@@ -64,11 +52,6 @@ class LoggedStatement extends PDOStatement
         return $result;
     }
 
-    /**
-     * @param array|null $inputParameters
-     *
-     * @return void
-     */
     private function log(?array $inputParameters) : void
     {
         if ($inputParameters !== null) {

--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -29,13 +29,25 @@ class LoggedStatement extends PDOStatement
         $this->logEntry['statement'] = $this->queryString;
     }
 
-    public function execute(array $inputParameters = null) : bool
+    /**
+     * @param array|null $inputParameters
+     *
+     * @return bool
+     */
+    public function execute(?array $inputParameters = null) : bool
     {
         $result = parent::execute($inputParameters);
         $this->log($inputParameters);
         return $result;
     }
 
+    /**
+     * @param string|int $parameter
+     * @param mixed      $value
+     * @param int        $dataType
+     *
+     * @return bool
+     */
     public function bindValue(
         string|int $parameter,
         mixed $value,
@@ -52,6 +64,11 @@ class LoggedStatement extends PDOStatement
         return $result;
     }
 
+    /**
+     * @param array|null $inputParameters
+     *
+     * @return void
+     */
     private function log(?array $inputParameters) : void
     {
         if ($inputParameters !== null) {

--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -13,8 +13,15 @@ namespace Atlas\Pdo;
 use PDO;
 use PDOStatement;
 
+/**
+ * @phpstan-import-type  logEntry from Connection
+ */
 class LoggedStatement extends PDOStatement
 {
+    /**
+     * @param callable $queryLogger
+     * @param logEntry $logEntry
+     */
     protected function __construct(
         protected mixed /* callable */ $queryLogger,
         protected array $logEntry
@@ -30,14 +37,15 @@ class LoggedStatement extends PDOStatement
     }
 
     public function bindValue(
-        mixed $parameter,
+        string|int $parameter,
         mixed $value,
         int $dataType = PDO::PARAM_STR
     ) : bool
     {
+        /** @var int|string $parameter */
         $result = parent::bindValue($parameter, $value, $dataType);
 
-        if ($result && $this->logEntry !== null) {
+        if ($result && !empty($this->logEntry)) {
             $this->logEntry['values'][$parameter] = $value;
         }
 

--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -14,16 +14,16 @@ use PDO;
 use PDOStatement;
 
 /**
- * @phpstan-import-type  logEntry from Connection
+ * @phpstan-import-type  logEntryType from Connection
  */
 class LoggedStatement extends PDOStatement
 {
     /**
-     * @param callable $queryLogger
-     * @param logEntry $logEntry
+     * @param callable     $queryLogger
+     * @param logEntryType $logEntry
      */
     protected function __construct(
-        protected mixed /* callable */ $queryLogger,
+        protected mixed $queryLogger,
         protected array $logEntry
     ) {
         $this->logEntry['statement'] = $this->queryString;
@@ -45,7 +45,7 @@ class LoggedStatement extends PDOStatement
         /** @var int|string $parameter */
         $result = parent::bindValue($parameter, $value, $dataType);
 
-        if ($result && !empty($this->logEntry)) {
+        if ($result && $this->logEntry !== null) {
             $this->logEntry['values'][$parameter] = $value;
         }
 

--- a/src/PdoCustomTypes.php
+++ b/src/PdoCustomTypes.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ *
+ * This file is part of Atlas for PHP.
+ *
+ * @license https://opensource.org/licenses/MIT MIT
+ *
+ */
+declare(strict_types=1);
+
+namespace Atlas\Pdo;
+
+/**
+ * @phpstan-type connection_entry array<string, ?Connection>
+ *
+ * @phpstan-type connection_store_array array{
+ *      DEFAULT: ?Connection,
+ *      READ: connection_entry,
+ *      WRITE: connection_entry
+ * }
+ *
+ * @phpstan-type dsn_args_array array{
+ *       dsn: string,
+ *       username?: string,
+ *       password?: string,
+ *       options?: array<int, mixed>
+ *   }
+ *
+ * @phpstan-type log_entry_array array{
+ *       start: float,
+ *       finish: ?float,
+ *       duration: ?float,
+ *       performed: ?bool,
+ *       statement: ?string,
+ *       values: array<array-key, mixed>,
+ *       trace: ?string,
+ *        connection?: string
+ *  }
+ *
+ * @phpstan-type fetch_assoc_array mixed[]
+ *
+ * @phpstan-type fetch_string_mixed_array array<string, mixed>
+ *
+ */
+final class PdoCustomTypes
+{
+}

--- a/src/PdoCustomTypes.php
+++ b/src/PdoCustomTypes.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 namespace Atlas\Pdo;
 
 /**
- * @phpstan-type connection_entry array<string, ?Connection>
+ * @phpstan-type connection_store_entry_array array<string, Connection>
  *
  * @phpstan-type connection_store_array array{
  *      DEFAULT: ?Connection,
- *      READ: connection_entry,
- *      WRITE: connection_entry
+ *      READ: connection_store_entry_array,
+ *      WRITE: connection_store_entry_array
  * }
  *
  * @phpstan-type dsn_args_array array{

--- a/src/PersistentLoggedStatement.php
+++ b/src/PersistentLoggedStatement.php
@@ -51,22 +51,11 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Attributes */
 
-    /**
-     * @param int   $attribute
-     * @param mixed $value
-     *
-     * @return bool
-     */
     public function setAttribute(int $attribute, mixed $value) : bool
     {
         return $this->parent->setAttribute($attribute, $value);
     }
 
-    /**
-     * @param int $attribute
-     *
-     * @return mixed
-     */
     public function getAttribute(int $attribute) : mixed
     {
         return $this->parent->getAttribute($attribute);
@@ -74,15 +63,6 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Binding */
 
-    /**
-     * @param mixed      $column
-     * @param mixed      $param
-     * @param int        $type
-     * @param int        $maxlen
-     * @param mixed|null $driverdata
-     *
-     * @return bool
-     */
     public function bindColumn(
         mixed $column,
         mixed &$param,
@@ -146,11 +126,6 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Execution */
 
-    /**
-     * @param array|null $inputParameters
-     *
-     * @return bool
-     */
     public function execute(?array $inputParameters = null) : bool
     {
         $result = $this->parent->execute($inputParameters);
@@ -160,24 +135,11 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Fetching */
 
-    /**
-     * @param int   $mode
-     * @param mixed ...$args
-     *
-     * @return bool
-     */
     public function setFetchMode(int $mode, mixed ...$args) : bool
     {
         return $this->parent->setFetchMode($mode, ...$args);
     }
 
-    /**
-     * @param int $fetch_style
-     * @param int $cursor_orientation
-     * @param int $cursor_offset
-     *
-     * @return mixed
-     */
     public function fetch(
         int $fetch_style = PDO::FETCH_DEFAULT,
         int $cursor_orientation = PDO::FETCH_ORI_NEXT,
@@ -187,12 +149,6 @@ class PersistentLoggedStatement extends PDOStatement
         return $this->parent->fetch($fetch_style, $cursor_orientation, $cursor_offset);
     }
 
-    /**
-     * @param int   $fetch_style
-     * @param mixed ...$args
-     *
-     * @return array
-     */
     public function fetchAll(
         int $fetch_style = PDO::FETCH_DEFAULT,
         mixed ...$args
@@ -202,11 +158,6 @@ class PersistentLoggedStatement extends PDOStatement
         return $this->parent->fetchAll($fetch_style, ...$args);
     }
 
-    /**
-     * @param int $column_number
-     *
-     * @return mixed
-     */
     public function fetchColumn(int $column_number = 0) : mixed
     {
         return $this->parent->fetchColumn($column_number);
@@ -230,27 +181,16 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Metadata */
 
-    /**
-     * @return int
-     */
     public function rowCount() : int
     {
         return $this->parent->rowCount();
     }
 
-    /**
-     * @return int
-     */
     public function columnCount() : int
     {
         return $this->parent->columnCount();
     }
 
-    /**
-     * @param int $column
-     *
-     * @return array|false
-     */
     public function getColumnMeta(int $column) : array|false
     {
         return $this->parent->getColumnMeta($column);
@@ -258,17 +198,11 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Errors */
 
-    /**
-     * @return string|null
-     */
     public function errorCode() : ?string
     {
         return $this->parent->errorCode();
     }
 
-    /**
-     * @return array
-     */
     public function errorInfo() : array
     {
         return $this->parent->errorInfo();
@@ -276,35 +210,21 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Other */
 
-    /**
-     * @return bool
-     */
     public function closeCursor() : bool
     {
         return $this->parent->closeCursor();
     }
 
-    /**
-     * @return bool|null
-     */
     public function debugDumpParams() : ?bool
     {
         return $this->parent->debugDumpParams();
     }
 
-    /**
-     * @return bool
-     */
     public function nextRowset() : bool
     {
         return $this->parent->nextRowset();
     }
 
-    /**
-     * @param array|null $inputParameters
-     *
-     * @return void
-     */
     private function log(?array $inputParameters) : void
     {
         if ($inputParameters !== null) {

--- a/src/PersistentLoggedStatement.php
+++ b/src/PersistentLoggedStatement.php
@@ -14,8 +14,18 @@ use BadMethodCallException;
 use PDO;
 use PDOStatement;
 
+/**
+ * @phpstan-import-type logEntry from Connection
+ */
 class PersistentLoggedStatement extends PDOStatement
 {
+    /**
+     * @param PDOStatement $parent
+     * @param callable     $queryLogger
+     * @param logEntry     $logEntry
+     *
+     * @return static
+     */
     static public function new(
         PDOStatement $parent,
         callable $queryLogger,
@@ -31,11 +41,15 @@ class PersistentLoggedStatement extends PDOStatement
 
     private PDOStatement $parent;
 
+    /** @var callable  */
     private mixed /* callable */ $queryLogger;
 
+    /**
+     * @var logEntry
+     */
     private array $logEntry;
 
-    /* Atttributes */
+    /* Attributes */
 
     public function setAttribute(int $attribute, mixed $value) : bool
     {
@@ -63,7 +77,7 @@ class PersistentLoggedStatement extends PDOStatement
     }
 
     public function bindParam(
-        mixed $parameter,
+        string|int $parameter,
         mixed &$variable,
         int $data_type = PDO::PARAM_STR,
         int $length = 0,
@@ -80,7 +94,7 @@ class PersistentLoggedStatement extends PDOStatement
     }
 
     public function bindValue(
-        mixed $parameter,
+        string|int $parameter,
         mixed $value,
         int $dataType = PDO::PARAM_STR
     ) : bool
@@ -107,37 +121,46 @@ class PersistentLoggedStatement extends PDOStatement
 
     public function setFetchMode(int $mode, mixed ...$args) : bool
     {
-        return $this->parent->setFetchMode(...func_get_args());
+        return $this->parent->setFetchMode($mode, ...$args);
     }
 
     public function fetch(
-        int $fetch_style = null,
+        int $fetch_style = PDO::FETCH_DEFAULT,
         int $cursor_orientation = PDO::FETCH_ORI_NEXT,
         int $cursor_offset = 0
     ) : mixed
     {
-        return $this->parent->fetch(...func_get_args());
+        return $this->parent->fetch($fetch_style, $cursor_orientation, $cursor_offset);
     }
 
     public function fetchAll(
-        int $fetch_style = PDO::FETCH_BOTH,
+        int $fetch_style = PDO::FETCH_DEFAULT,
         mixed ...$args
-    ) : array|false
+    ) : array
     {
-        return $this->parent->fetchAll(...func_get_args());
+        /** @var array<array-key, callable|int|string> $args */
+        return $this->parent->fetchAll($fetch_style, ...$args);
     }
 
     public function fetchColumn(int $column_number = 0) : mixed
     {
-        return $this->parent->fetchColumn(...func_get_args());
+        return $this->parent->fetchColumn($column_number);
     }
 
+    /**
+     * @template T of object
+     * @param class-string<T> $class_name
+     * @param array           $ctor_args
+     *
+     * @return T|false
+     */
     public function fetchObject(
         ?string $class_name = 'stdClass',
-        ?array $ctor_args = []
+        array $ctor_args = []
     ) : object|false
     {
-        return $this->parent->fetchObject(...func_get_args());
+        /** @var class-string<T> $class_name */
+        return $this->parent->fetchObject($class_name, $ctor_args);
     }
 
     /* Metadata */
@@ -154,7 +177,7 @@ class PersistentLoggedStatement extends PDOStatement
 
     public function getColumnMeta(int $column) : array|false
     {
-        return $this->parent->getColumnMeta(...func_get_args());
+        return $this->parent->getColumnMeta($column);
     }
 
     /* Errors */
@@ -164,7 +187,7 @@ class PersistentLoggedStatement extends PDOStatement
         return $this->parent->errorCode();
     }
 
-    public function errorInfo() : ?array
+    public function errorInfo() : array
     {
         return $this->parent->errorInfo();
     }

--- a/src/PersistentLoggedStatement.php
+++ b/src/PersistentLoggedStatement.php
@@ -51,11 +51,22 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Attributes */
 
+    /**
+     * @param int   $attribute
+     * @param mixed $value
+     *
+     * @return bool
+     */
     public function setAttribute(int $attribute, mixed $value) : bool
     {
         return $this->parent->setAttribute($attribute, $value);
     }
 
+    /**
+     * @param int $attribute
+     *
+     * @return mixed
+     */
     public function getAttribute(int $attribute) : mixed
     {
         return $this->parent->getAttribute($attribute);
@@ -63,6 +74,15 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Binding */
 
+    /**
+     * @param mixed      $column
+     * @param mixed      $param
+     * @param int        $type
+     * @param int        $maxlen
+     * @param mixed|null $driverdata
+     *
+     * @return bool
+     */
     public function bindColumn(
         mixed $column,
         mixed &$param,
@@ -76,6 +96,15 @@ class PersistentLoggedStatement extends PDOStatement
         );
     }
 
+    /**
+     * @param string|int $parameter
+     * @param mixed      $variable
+     * @param int        $data_type
+     * @param int        $length
+     * @param mixed|null $driver_options
+     *
+     * @return bool
+     */
     public function bindParam(
         string|int $parameter,
         mixed &$variable,
@@ -93,6 +122,13 @@ class PersistentLoggedStatement extends PDOStatement
         );
     }
 
+    /**
+     * @param string|int $parameter
+     * @param mixed      $value
+     * @param int        $dataType
+     *
+     * @return bool
+     */
     public function bindValue(
         string|int $parameter,
         mixed $value,
@@ -110,7 +146,12 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Execution */
 
-    public function execute(array $inputParameters = null) : bool
+    /**
+     * @param array|null $inputParameters
+     *
+     * @return bool
+     */
+    public function execute(?array $inputParameters = null) : bool
     {
         $result = $this->parent->execute($inputParameters);
         $this->log($inputParameters);
@@ -119,11 +160,24 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Fetching */
 
+    /**
+     * @param int   $mode
+     * @param mixed ...$args
+     *
+     * @return bool
+     */
     public function setFetchMode(int $mode, mixed ...$args) : bool
     {
         return $this->parent->setFetchMode($mode, ...$args);
     }
 
+    /**
+     * @param int $fetch_style
+     * @param int $cursor_orientation
+     * @param int $cursor_offset
+     *
+     * @return mixed
+     */
     public function fetch(
         int $fetch_style = PDO::FETCH_DEFAULT,
         int $cursor_orientation = PDO::FETCH_ORI_NEXT,
@@ -133,6 +187,12 @@ class PersistentLoggedStatement extends PDOStatement
         return $this->parent->fetch($fetch_style, $cursor_orientation, $cursor_offset);
     }
 
+    /**
+     * @param int   $fetch_style
+     * @param mixed ...$args
+     *
+     * @return array
+     */
     public function fetchAll(
         int $fetch_style = PDO::FETCH_DEFAULT,
         mixed ...$args
@@ -142,6 +202,11 @@ class PersistentLoggedStatement extends PDOStatement
         return $this->parent->fetchAll($fetch_style, ...$args);
     }
 
+    /**
+     * @param int $column_number
+     *
+     * @return mixed
+     */
     public function fetchColumn(int $column_number = 0) : mixed
     {
         return $this->parent->fetchColumn($column_number);
@@ -165,16 +230,27 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Metadata */
 
+    /**
+     * @return int
+     */
     public function rowCount() : int
     {
         return $this->parent->rowCount();
     }
 
+    /**
+     * @return int
+     */
     public function columnCount() : int
     {
         return $this->parent->columnCount();
     }
 
+    /**
+     * @param int $column
+     *
+     * @return array|false
+     */
     public function getColumnMeta(int $column) : array|false
     {
         return $this->parent->getColumnMeta($column);
@@ -182,11 +258,17 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Errors */
 
+    /**
+     * @return string|null
+     */
     public function errorCode() : ?string
     {
         return $this->parent->errorCode();
     }
 
+    /**
+     * @return array
+     */
     public function errorInfo() : array
     {
         return $this->parent->errorInfo();
@@ -194,21 +276,35 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Other */
 
+    /**
+     * @return bool
+     */
     public function closeCursor() : bool
     {
         return $this->parent->closeCursor();
     }
 
+    /**
+     * @return bool|null
+     */
     public function debugDumpParams() : ?bool
     {
         return $this->parent->debugDumpParams();
     }
 
+    /**
+     * @return bool
+     */
     public function nextRowset() : bool
     {
         return $this->parent->nextRowset();
     }
 
+    /**
+     * @param array|null $inputParameters
+     *
+     * @return void
+     */
     private function log(?array $inputParameters) : void
     {
         if ($inputParameters !== null) {

--- a/src/PersistentLoggedStatement.php
+++ b/src/PersistentLoggedStatement.php
@@ -16,14 +16,14 @@ use PDOStatement;
 use ReturnTypeWillChange;
 
 /**
- * @phpstan-import-type logEntryType from Connection
+ * @phpstan-import-type log_entry_array from PdoCustomTypes
  */
 class PersistentLoggedStatement extends PDOStatement
 {
     /**
-     * @param PDOStatement $parent
-     * @param callable     $queryLogger
-     * @param logEntryType $logEntry
+     * @param PDOStatement    $parent
+     * @param callable        $queryLogger
+     * @param log_entry_array $logEntry
      *
      * @return static
      */
@@ -46,7 +46,7 @@ class PersistentLoggedStatement extends PDOStatement
     private mixed /* callable */ $queryLogger;
 
     /**
-     * @var logEntryType
+     * @var log_entry_array
      */
     private array $logEntry;
 

--- a/src/PersistentLoggedStatement.php
+++ b/src/PersistentLoggedStatement.php
@@ -106,7 +106,7 @@ class PersistentLoggedStatement extends PDOStatement
      * @return bool
      */
     public function bindParam(
-        string|int $parameter,
+        mixed $parameter,
         mixed &$variable,
         int $data_type = PDO::PARAM_STR,
         int $length = 0,
@@ -130,7 +130,7 @@ class PersistentLoggedStatement extends PDOStatement
      * @return bool
      */
     public function bindValue(
-        string|int $parameter,
+        mixed $parameter,
         mixed $value,
         int $dataType = PDO::PARAM_STR
     ) : bool

--- a/src/PersistentLoggedStatement.php
+++ b/src/PersistentLoggedStatement.php
@@ -13,6 +13,7 @@ namespace Atlas\Pdo;
 use BadMethodCallException;
 use PDO;
 use PDOStatement;
+use ReturnTypeWillChange;
 
 /**
  * @phpstan-import-type logEntryType from Connection
@@ -135,6 +136,7 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Fetching */
 
+    #[ReturnTypeWillChange]
     public function setFetchMode(int $mode, mixed ...$args) : bool
     {
         return $this->parent->setFetchMode($mode, ...$args);

--- a/src/PersistentLoggedStatement.php
+++ b/src/PersistentLoggedStatement.php
@@ -15,14 +15,14 @@ use PDO;
 use PDOStatement;
 
 /**
- * @phpstan-import-type logEntry from Connection
+ * @phpstan-import-type logEntryType from Connection
  */
 class PersistentLoggedStatement extends PDOStatement
 {
     /**
      * @param PDOStatement $parent
      * @param callable     $queryLogger
-     * @param logEntry     $logEntry
+     * @param logEntryType $logEntry
      *
      * @return static
      */
@@ -45,7 +45,7 @@ class PersistentLoggedStatement extends PDOStatement
     private mixed /* callable */ $queryLogger;
 
     /**
-     * @var logEntry
+     * @var logEntryType
      */
     private array $logEntry;
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -4,8 +4,13 @@ namespace Atlas\Pdo;
 use PDO;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
+/**
+ * For PHP 8.1+, a change was introduced to the PDO MySQL and Sqlite drivers
+ * regarding how integer and float values are fetched from the database.
+ * Although this affects emulated prepares, the tests below cast the values
+ * to strings to achieve consistency between PHP versions
+ */
 class ConnectionTest extends TestCase
 {
     protected PDO $pdo;
@@ -16,15 +21,15 @@ class ConnectionTest extends TestCase
      * @var string[]
      */
     protected $data = [
-        1  => 'Anna',
-        2  => 'Betty',
-        3  => 'Clara',
-        4  => 'Donna',
-        5  => 'Fiona',
-        6  => 'Gertrude',
-        7  => 'Hanna',
-        8  => 'Ione',
-        9  => 'Julia',
+        1 => 'Anna',
+        2 => 'Betty',
+        3 => 'Clara',
+        4 => 'Donna',
+        5 => 'Fiona',
+        6 => 'Gertrude',
+        7 => 'Hanna',
+        8 => 'Ione',
+        9 => 'Julia',
         10 => 'Kara',
     ];
 
@@ -136,7 +141,7 @@ class ConnectionTest extends TestCase
     {
         $stm = "SELECT id, name FROM pdotest WHERE id = :id";
         $actual = $this->connection->fetchObject($stm, ['id' => 1]);
-        $this->assertSame(1, $actual->id);
+        $this->assertSame('1', (string)$actual->id);
         $this->assertSame('Anna', $actual->name);
     }
 
@@ -149,7 +154,7 @@ class ConnectionTest extends TestCase
             'Atlas\Pdo\FakeObject',
             ['bar']
         );
-        $this->assertSame(1, $actual->id);
+        $this->assertSame('1', (string)$actual->id);
         $this->assertSame('Anna', $actual->name);
         $this->assertSame('bar', $actual->foo);
     }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -3,24 +3,28 @@ namespace Atlas\Pdo;
 
 use PDO;
 use PDOStatement;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
-class ConnectionTest extends \PHPUnit\Framework\TestCase
+class ConnectionTest extends TestCase
 {
-    protected $pdo;
+    protected PDO $pdo;
 
-    protected $connection;
+    protected Connection $connection;
 
+    /**
+     * @var string[]
+     */
     protected $data = [
-        1 => 'Anna',
-        2 => 'Betty',
-        3 => 'Clara',
-        4 => 'Donna',
-        5 => 'Fiona',
-        6 => 'Gertrude',
-        7 => 'Hanna',
-        8 => 'Ione',
-        9 => 'Julia',
+        1  => 'Anna',
+        2  => 'Betty',
+        3  => 'Clara',
+        4  => 'Donna',
+        5  => 'Fiona',
+        6  => 'Gertrude',
+        7  => 'Hanna',
+        8  => 'Ione',
+        9  => 'Julia',
         10 => 'Kara',
     ];
 
@@ -132,7 +136,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
     {
         $stm = "SELECT id, name FROM pdotest WHERE id = :id";
         $actual = $this->connection->fetchObject($stm, ['id' => 1]);
-        $this->assertSame('1', $actual->id);
+        $this->assertSame(1, $actual->id);
         $this->assertSame('Anna', $actual->name);
     }
 
@@ -145,7 +149,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
             'Atlas\Pdo\FakeObject',
             ['bar']
         );
-        $this->assertSame('1', $actual->id);
+        $this->assertSame(1, $actual->id);
         $this->assertSame('Anna', $actual->name);
         $this->assertSame('bar', $actual->foo);
     }

--- a/tests/FakeObject.php
+++ b/tests/FakeObject.php
@@ -1,7 +1,9 @@
 <?php
 namespace Atlas\Pdo;
 
-class FakeObject
+use stdClass;
+
+class FakeObject extends stdClass
 {
     public $foo;
 

--- a/tests/PersistentLoggedStatementTest.php
+++ b/tests/PersistentLoggedStatementTest.php
@@ -6,6 +6,8 @@ use PDO;
 
 class PersistentLoggedStatementTest extends \PHPUnit\Framework\TestCase
 {
+    protected Connection $connection;
+
     /**
      * @var string[]
      */
@@ -76,8 +78,14 @@ class PersistentLoggedStatementTest extends \PHPUnit\Framework\TestCase
 
         $sth->execute();
 
-        $expect = ['id' => 1, 'name' => 'Anna'];
+        $expect = ['id' => '1', 'name' => 'Anna'];
         $actual = $sth->fetch();
+
+        /**
+         * Keeping consistent with PHP 8.0 and 8.1+
+         */
+        $actual['id'] = (string) $actual['id'];
+
         $this->assertSame($expect, $actual);
     }
 
@@ -92,8 +100,11 @@ class PersistentLoggedStatementTest extends \PHPUnit\Framework\TestCase
 
         $sth->execute();
 
-        $expect = ['id' => 1, 'name' => 'Anna'];
+        $expect = ['id' => '1', 'name' => 'Anna'];
         $actual = $sth->fetch();
+
+        $actual['id'] = (string) $actual['id'];
+
         $this->assertSame($expect, $actual);
     }
 
@@ -107,17 +118,21 @@ class PersistentLoggedStatementTest extends \PHPUnit\Framework\TestCase
         $sth->execute();
 
         $actual = $sth->fetchAll();
+        $actual[0]['id'] = (string) $actual[0]['id'];
+        $actual[1]['id'] = (string) $actual[1]['id'];
+        $actual[2]['id'] = (string) $actual[2]['id'];
+
         $expect = [
             [
-                'id'   => 1,
+                'id' => '1',
                 'name' => 'Anna',
             ],
             [
-                'id'   => 2,
+                'id' => '2',
                 'name' => 'Betty',
             ],
             [
-                'id'   => 3,
+                'id' => '3',
                 'name' => 'Clara',
             ]
         ];

--- a/tests/PersistentLoggedStatementTest.php
+++ b/tests/PersistentLoggedStatementTest.php
@@ -3,11 +3,12 @@ namespace Atlas\Pdo;
 
 use BadMethodCallException;
 use PDO;
-use PDOStatement;
-use stdClass;
 
 class PersistentLoggedStatementTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var string[]
+     */
     protected $data = [
         1 => 'Anna',
         2 => 'Betty',
@@ -75,7 +76,7 @@ class PersistentLoggedStatementTest extends \PHPUnit\Framework\TestCase
 
         $sth->execute();
 
-        $expect = ['id' => '1', 'name' => 'Anna'];
+        $expect = ['id' => 1, 'name' => 'Anna'];
         $actual = $sth->fetch();
         $this->assertSame($expect, $actual);
     }
@@ -91,14 +92,16 @@ class PersistentLoggedStatementTest extends \PHPUnit\Framework\TestCase
 
         $sth->execute();
 
-        $expect = ['id' => '1', 'name' => 'Anna'];
+        $expect = ['id' => 1, 'name' => 'Anna'];
         $actual = $sth->fetch();
         $this->assertSame($expect, $actual);
     }
 
     public function testFetchAll()
     {
-        $sth = $this->connection->prepare('SELECT * FROM pdotest WHERE id <= 3 ORDER BY id');
+        $sth = $this->connection->prepare(
+            'SELECT * FROM pdotest WHERE id <= 3 ORDER BY id'
+        );
         $sth->setFetchMode(PDO::FETCH_ASSOC);
 
         $sth->execute();
@@ -106,15 +109,15 @@ class PersistentLoggedStatementTest extends \PHPUnit\Framework\TestCase
         $actual = $sth->fetchAll();
         $expect = [
             [
-                'id' => '1',
+                'id'   => 1,
                 'name' => 'Anna',
             ],
             [
-                'id' => '2',
+                'id'   => 2,
                 'name' => 'Betty',
             ],
             [
-                'id' => '3',
+                'id'   => 3,
                 'name' => 'Clara',
             ]
         ];


### PR DESCRIPTION
- ~Changed minimum version to PHP 8.1 << Please advise if this is acceptable~ (review)
- ~Added version to composer.json~ (review)
- Upgraded phpstan and phpunit (composer)
- Added github actions workflow to run phpstan and the tests
- ~Upgraded phpunit.xml.dist for the new phpunit version~ (review)
- ~Added docblocks for all methods~ (out of scope)
- Added phpstan types for logEntry, connection instances etc.
- Adjusted tests
- Changed implicitly nullable variables to accept null also (PHP 8.4)
- Changed logic in `LoggerStatement::bindValue()` to check with `empty()` instead of `null`
- Changed `PersistentStatement` usages of `func_get_args()` to passed parameters or vadiadic ones (soothing stan)
- Changed `PersistentStatement::errorInfo()` to return only array (parent interface changed)
- Changed `PersistentStatement::fetch()` to use `PDO::FETCH_DEFAULT` instead of `null`. 
- Changed `PersistentStatement::fetchAll()` to return `array` instead of `array|false` and use `PDO::FETCH_DEFAULT` instead of `PDO::FETCH_BOTH`. 

For this one we can also use `#[\ReturnTypeWillChange]` for now, since the return type `PersistentLoggedStatement::fetchAll()` is not covariant with `PDOStatement::fetchAll()`.  As for the mode change, the relevant test was failing without that change. We can either adjust the test or leave that change there.

Please advise what needs to be changed.

Thanks