### PR TITLE
Adjusments to run Atlas.Pdo with PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+name: Atlas.Pdo CI
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  workflow_dispatch:
+
+env:
+  fail-fast: true
+
+  # PHP extensions required by Composer
+  EXTENSIONS: pdo
+
+permissions:
+  contents: read
+
+jobs:
+
+#  # PHPStan
+#  quality:
+#    name: "Validate Quality"
+#    if: "!contains(github.event.head_commit.message, 'ci skip')"
+#
+#    permissions:
+#      contents: read
+#
+#    runs-on: ubuntu-22.04
+#
+#    strategy:
+#      fail-fast: true
+#      matrix:
+#        php:
+#          - '8.0'
+#          - '8.1'
+#          - '8.2'
+#          - '8.3'
+#          - '8.4'
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: "Setup PHP"
+#        uses: shivammathur/setup-php@2.35.3
+#        with:
+#          php-version: ${{ matrix.php }}
+#          extensions: ${{ env.EXTENSIONS }}
+#        env:
+#          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: "Install development dependencies with Composer"
+#        uses: "ramsey/composer-install@v3"
+#        with:
+#          composer-options: "--prefer-dist"
+#
+#      - name: "PHPStan"
+#        run: |
+#          composer stan
+#
+#
+  unit-tests:
+#    needs: quality
+
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+
+    name: Unit tests / PHP-${{ matrix.php }}
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        php:
+          - '8.0'
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Setup PHP"
+        uses: shivammathur/setup-php@2.35.3
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ env.EXTENSIONS }}
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Install development dependencies with Composer"
+        uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--prefer-dist"
+
+      - name: "Run Unit Tests"
+        if: always()
+        run: |
+          composer test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /composer.lock
 /vendor/*
 /.phpunit.result.cache
+/.bash_history
+.composer

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^8.0",
+        "ext-pdo": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -389,7 +389,7 @@ class Connection
         $this->queryLogger = $queryLogger;
     }
 
-    protected function newLogEntry(string $statement = null) : array
+    protected function newLogEntry(?string $statement = null) : array
     {
         return [
             'start' => microtime(true),

--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -22,7 +22,7 @@ class LoggedStatement extends PDOStatement
         $this->logEntry['statement'] = $this->queryString;
     }
 
-    public function execute(array $inputParameters = null) : bool
+    public function execute(?array $inputParameters = null) : bool
     {
         $result = parent::execute($inputParameters);
         $this->log($inputParameters);

--- a/src/PersistentLoggedStatement.php
+++ b/src/PersistentLoggedStatement.php
@@ -13,6 +13,7 @@ namespace Atlas\Pdo;
 use BadMethodCallException;
 use PDO;
 use PDOStatement;
+use ReturnTypeWillChange;
 
 class PersistentLoggedStatement extends PDOStatement
 {
@@ -96,7 +97,7 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Execution */
 
-    public function execute(array $inputParameters = null) : bool
+    public function execute(?array $inputParameters = null) : bool
     {
         $result = $this->parent->execute($inputParameters);
         $this->log($inputParameters);
@@ -105,13 +106,14 @@ class PersistentLoggedStatement extends PDOStatement
 
     /* Fetching */
 
+    #[ReturnTypeWillChange]
     public function setFetchMode(int $mode, mixed ...$args) : bool
     {
         return $this->parent->setFetchMode(...func_get_args());
     }
 
     public function fetch(
-        int $fetch_style = null,
+        ?int $fetch_style = null,
         int $cursor_orientation = PDO::FETCH_ORI_NEXT,
         int $cursor_offset = 0
     ) : mixed
@@ -119,6 +121,7 @@ class PersistentLoggedStatement extends PDOStatement
         return $this->parent->fetch(...func_get_args());
     }
 
+    #[ReturnTypeWillChange]
     public function fetchAll(
         int $fetch_style = PDO::FETCH_BOTH,
         mixed ...$args
@@ -164,6 +167,7 @@ class PersistentLoggedStatement extends PDOStatement
         return $this->parent->errorCode();
     }
 
+    #[ReturnTypeWillChange]
     public function errorInfo() : ?array
     {
         return $this->parent->errorInfo();

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -132,7 +132,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
     {
         $stm = "SELECT id, name FROM pdotest WHERE id = :id";
         $actual = $this->connection->fetchObject($stm, ['id' => 1]);
-        $this->assertSame('1', $actual->id);
+        $this->assertSame('1', (string)$actual->id);
         $this->assertSame('Anna', $actual->name);
     }
 
@@ -145,7 +145,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
             'Atlas\Pdo\FakeObject',
             ['bar']
         );
-        $this->assertSame('1', $actual->id);
+        $this->assertSame('1', (string)$actual->id);
         $this->assertSame('Anna', $actual->name);
         $this->assertSame('bar', $actual->foo);
     }

--- a/tests/FakeObject.php
+++ b/tests/FakeObject.php
@@ -1,7 +1,9 @@
 <?php
 namespace Atlas\Pdo;
 
-class FakeObject
+use stdClass;
+
+class FakeObject extends stdClass
 {
     public $foo;
 

--- a/tests/PersistentLoggedStatementTest.php
+++ b/tests/PersistentLoggedStatementTest.php
@@ -8,6 +8,8 @@ use stdClass;
 
 class PersistentLoggedStatementTest extends \PHPUnit\Framework\TestCase
 {
+    protected Connection $connection;
+
     protected $data = [
         1 => 'Anna',
         2 => 'Betty',
@@ -77,6 +79,12 @@ class PersistentLoggedStatementTest extends \PHPUnit\Framework\TestCase
 
         $expect = ['id' => '1', 'name' => 'Anna'];
         $actual = $sth->fetch();
+
+        /**
+         * Keeping consistent with PHP 8.0 and 8.1+
+         */
+        $actual['id'] = (string) $actual['id'];
+
         $this->assertSame($expect, $actual);
     }
 
@@ -93,6 +101,9 @@ class PersistentLoggedStatementTest extends \PHPUnit\Framework\TestCase
 
         $expect = ['id' => '1', 'name' => 'Anna'];
         $actual = $sth->fetch();
+
+        $actual['id'] = (string) $actual['id'];
+
         $this->assertSame($expect, $actual);
     }
 
@@ -104,6 +115,10 @@ class PersistentLoggedStatementTest extends \PHPUnit\Framework\TestCase
         $sth->execute();
 
         $actual = $sth->fetchAll();
+        $actual[0]['id'] = (string) $actual[0]['id'];
+        $actual[1]['id'] = (string) $actual[1]['id'];
+        $actual[2]['id'] = (string) $actual[2]['id'];
+
         $expect = [
             [
                 'id' => '1',


### PR DESCRIPTION
- Added github actions run for tests
- Added `ext-pdo` requirement in `composer.json`
- Changed `Connection::newLogEntry(string $statement = null)` to `newLogEntry(?string $statement = null)` (PHP 8.4)
- Changed `LoggedStatement::execute(array $inputParameters = null)` to `execute(?array $inputParameters = null)` (PHP 8.4)
- Changed `PersistentLoggedStatement::execute(array $inputParameters = null)` to `execute(?array $inputParameters = null)` (PHP 8.4)
- Added `#[ReturnTypeWillChange]` to suppress PHP 8.4 warnings in `PersistentLoggedStatement`
- Adjusted tests, forcing string comparisons for ID fields
