### PR TITLE
Fix broken query logging

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -13,6 +13,7 @@ namespace Atlas\Pdo;
 use Generator;
 use PDO;
 use PDOStatement;
+use Throwable;
 
 /**
  * Decorator for PDO instances.
@@ -142,7 +143,15 @@ class Connection
         array $values = []
     ) : PDOStatement
     {
-        $sth = $this->prepare($statement);
+        try {
+            $sth = $this->prepare($statement);
+        } catch (Throwable $error) {
+            $this->addLogEntry(
+                $this->newLogEntry($statement, $error)
+            );
+
+            throw $error;
+        }
 
         foreach ($values as $name => $args) {
             $this->performBind($sth, $name, $args);
@@ -180,9 +189,11 @@ class Connection
     public function query(string $statement, mixed ...$fetch) : PDOStatement|false
     {
         $entry = $this->newLogEntry($statement);
-        $sth = $this->pdo->query($statement, ...$fetch);
-        $this->addLogEntry($entry);
-        return $sth;
+        try {
+            return $this->pdo->query($statement, ...$fetch);
+        } finally {
+            $this->addLogEntry($entry);
+        }
     }
 
     /* Fetching */
@@ -389,16 +400,17 @@ class Connection
         $this->queryLogger = $queryLogger;
     }
 
-    protected function newLogEntry(?string $statement = null) : array
+    protected function newLogEntry(?string $statement = null, ?\Throwable $error = null) : array
     {
         return [
             'start' => microtime(true),
             'finish' => null,
             'duration' => null,
-            'performed' => null,
+            'performed' => $error ? false : null,
             'statement' => $statement,
             'values' => [],
-            'trace' => null,
+            'trace' => $error ? $error->getTrace() : null,
+            'error' => $error,
         ];
     }
 
@@ -406,6 +418,10 @@ class Connection
     {
         if (! $this->logQueries) {
             return;
+        }
+
+        if ($entry['error']) {
+            $entry['performed'] = false;
         }
 
         if ($entry['performed'] === null) {

--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -25,9 +25,11 @@ class LoggedStatement extends PDOStatement
 
     public function execute(?array $inputParameters = null) : bool
     {
-        $result = parent::execute($inputParameters);
-        $this->log($inputParameters);
-        return $result;
+        try {
+            return parent::execute($inputParameters);
+        } finally {
+            $this->log($inputParameters);
+        }
     }
 
     public function bindValue(

--- a/src/LoggedStatement.php
+++ b/src/LoggedStatement.php
@@ -20,6 +20,7 @@ class LoggedStatement extends PDOStatement
         protected array $logEntry
     ) {
         $this->logEntry['statement'] = $this->queryString;
+        $this->logEntry['start'] = microtime(true);
     }
 
     public function execute(?array $inputParameters = null) : bool


### PR DESCRIPTION
This fixes two issues:

1. Duration values stack with each subsequent query, rendering using the logging feature for benchmarking queries useless.
2. Fix query logging even in the event of an error, which doesn't currently happen
